### PR TITLE
Fixed venv failing to get installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
         chdir: "{{ checkout_dest }}"
         requirements: "requirements.txt"
         virtualenv: "{{ checkout_dest }}/venv"
-        virtualenv_command: "python3.8 -m venv"
+        virtualenv_command: "/usr/bin/python3.8 -m venv"
     ### end install-ssh-deploy-key
    
     - name: "configure ssh to use {{ ssh_config_dir }}"


### PR DESCRIPTION
This PR overcomes the issue that Sean and I were seeing where the `python3.8 -m venv` command was not finding the executable in the path.